### PR TITLE
Test with newer versions of node and update package.json engines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,39 @@
-language: node_js
-node_js:
-- "8"
-- "7"
-- "6"
-- "5"
-- "4"
-- "0.12"
+jobs:
+  include:
+    - language: node_js
+      node_js: 0.12
+
+    - name: "Node.js: 4"
+      language: minimal
+      install:
+        - nvm install 4
+        # Yarn v1.12.3 is last *known* version to work on node v4/v5
+        # See: https://github.com/yarnpkg/yarn/issues/6914
+        - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.3
+        - export PATH="$HOME/.yarn/bin:$PATH"
+        - yarn version
+      script:
+        - yarn
+        - yarn run test
+
+    - name: "Node.js: 5"
+      language: minimal
+      install:
+        - nvm install 5
+        # Yarn v1.12.3 is last *known* version to work on node v4/v5
+        # See: https://github.com/yarnpkg/yarn/issues/6914
+        - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.3
+        - export PATH="$HOME/.yarn/bin:$PATH"
+        - yarn version
+      script:
+        - yarn
+        - yarn run test
+
+    - language: node_js
+      node_js: 6
+
+    - language: node_js
+      node_js: 7
+
+    - language: node_js
+      node_js: 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,12 @@ jobs:
 
     - language: node_js
       node_js: 8
+
+    - language: node_js
+      node_js: 10
+
+    - language: node_js
+      node_js: 12
+
+    - language: node_js
+      node_js: 13

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/cmawhorter/urn/issues"
   },
   "engines": {
-    "node": ">=0.12.0 - <9.0.0"
+    "node": ">=0.12.0 - <14.0.0"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
This PR fixes #3. The commits in this PR:

- Fix broken Travis CI builds for Node 4/5. They're broken because the version of yarn installed on Travis' default Node 4 and Node 5 versions fails while running `yarn version`. See yarn bug https://github.com/yarnpkg/yarn/issues/6914

- Add all currently supported Node versions to CI (10, 12, 13). All pass existing tests.

- Update package.json engines field to reflect new testing.
